### PR TITLE
DocumenterCitations

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 AlgebraicTemplate = "b66562e1-fa90-4e8b-9505-c909188fab76"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
 using Documenter
+using DocumenterCitations
 using Literate
 
 const literate_dir = joinpath(@__DIR__, "literate")
@@ -32,6 +33,10 @@ if !no_literate
   end
 end
 
+bib = CitationBibliography(
+    joinpath(@__DIR__, "src", "documenter.bib");
+    style=:numeric)
+
 @info "Building Documenter.jl docs"
 makedocs(
   modules=[AlgebraicTemplate],
@@ -42,15 +47,14 @@ makedocs(
   pages=Any[
     "AlgebraicTemplate.jl"=>"index.md",
     "Examples"=>Any[
-      "generated/literate_example.md",
-    ],
-    "Library Reference"=>"api.md",
-  ]
-)
+      "generated/literate_example.md",],
+    "Library Reference"=>"api.md",],
+  plugins=[bib])
+
 
 @info "Deploying docs"
 deploydocs(
   target="build",
   repo="github.com/AlgebraicJulia/AlgebraicTemplate.jl.git",
-  branch="gh-pages"
-)
+  branch="gh-pages")
+

--- a/docs/src/documenter.bib
+++ b/docs/src/documenter.bib
@@ -1,0 +1,9 @@
+
+@article{glen_flow_1958,
+	title = {The flow law of ice: {A} discussion of the assumptions made in glacier theory, their experimental foundations and consequences},
+	volume = {47},
+	journal = {IASH Publ},
+	author = {Glen, JW},
+	year = {1958},
+	pages = {171--183},
+}


### PR DESCRIPTION
DocumenterCitations.jl is a package that lets you cite works in your docstrings and docs pages just as if you were citing a work in LaTeX: `[glen_flow_1958](@cite)`. You can gather your references together in your shared Zotero, and simply upload the exported `.bib` file to the repo. You can also create bibliographies using `@bibliography` environment blocks.